### PR TITLE
Mutex needs `require 'thread'` in Ruby <1.9

### DIFF
--- a/lib/eutils.rb
+++ b/lib/eutils.rb
@@ -2,6 +2,7 @@ require 'cgi'
 require 'net/http'
 require 'uri'
 require 'active_support/core_ext/hash/conversions'
+require 'thread'
 # Synopsis
 # eutils = Eutils.new("medvane", "joon@medvane.org")
 # eutils.einfo


### PR DESCRIPTION
Trying to load the library on a Ruby 1.8 results in an error about an undefined constant `Mutex`

This is solved by requiring `thread`.

I would build a test case for this, but it is a straightforward change and unfortunately your testing suite uses `shoulda` which doesn't work on Ruby 1.8.
