### PR TITLE
HTTPS is required now

### DIFF
--- a/lib/eutils.rb
+++ b/lib/eutils.rb
@@ -10,7 +10,7 @@ class Eutils
   # Global constants
   # * host: http://http://eutils.ncbi.nlm.nih.gov
   # * EUTILS_INTERVAL
-  EUTILS_HOST = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
+  EUTILS_HOST = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
   EUTILS_INTERVAL = 1.0 / 3.0
   @@last_access = nil
   @@last_access_mutex = nil


### PR DESCRIPTION
Now we need to access E-utils via HTTPS
https://www.ncbi.nlm.nih.gov/news/06-10-2016-ncbi-https/
